### PR TITLE
Mark constructors with single argument explicit

### DIFF
--- a/src/BusyPopup.h
+++ b/src/BusyPopup.h
@@ -43,9 +43,9 @@ public:
      * If 'autoPost' is 'true', automatically post it, i.e. show it and
      * process events for some milliseconds to makes sure it is rendered.
      **/
-    BusyPopup( const QString & text,
-               QWidget *       parent   = 0,
-               bool	       autoPost = true );
+    explicit BusyPopup( const QString & text,
+                        QWidget *       parent   = 0,
+                        bool            autoPost = true );
 
     /**
      * Destructor.

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -27,7 +27,7 @@ public:
     /**
      * Constructor.
      */
-    Exception( const QString &msg = QString() ):
+    explicit Exception( const QString &msg = QString() ):
 	_what( msg ),
 	_srcLine(0)
 	{}
@@ -173,7 +173,7 @@ private:
 class DynamicCastException: public Exception
 {
 public:
-    DynamicCastException( const QString &expectedType ):
+    explicit DynamicCastException( const QString &expectedType ):
 	Exception( "dynamic_cast failed; expected: " + expectedType )
 	{}
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -103,7 +103,7 @@ public:
      * The first logger created is also implicitly used as the default
      * logger. This can be changed later with setDefaultLogger().
      */
-    Logger( const QString & filename );
+    explicit Logger( const QString & filename );
 
     /**
      * Constructor: Create a logger that logs to 'filename' in directory

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -45,7 +45,7 @@ public:
     /**
      * Constructor
      **/
-    MainWindow( QWidget * parent = 0 );
+    explicit MainWindow( QWidget * parent = 0 );
 
     /**
      * Destructor

--- a/src/PkgTaskListWidget.h
+++ b/src/PkgTaskListWidget.h
@@ -34,7 +34,7 @@ class PkgTaskListWidget: public QListWidget
 
 public:
 
-    PkgTaskListWidget( QWidget * parent )
+    explicit PkgTaskListWidget( QWidget * parent )
         : QListWidget( parent )
         , _nextSerial( 0 )
         , _sortByInsertionSequence( true )
@@ -108,8 +108,8 @@ class PkgTaskListWidgetItem: public QListWidgetItem
 {
 public:
 
-    PkgTaskListWidgetItem( PkgTask *           task,
-                           PkgTaskListWidget * parent = 0 );
+    explicit PkgTaskListWidgetItem( PkgTask *           task,
+                                    PkgTaskListWidget * parent = 0 );
 
     PkgTask * task() const { return _task; }
 

--- a/src/PkgTasks.h
+++ b/src/PkgTasks.h
@@ -226,7 +226,7 @@ public:
     /**
      * Constructor.
      **/
-    PkgTaskList( const QString & listName );
+    explicit PkgTaskList( const QString & listName );
 
     /**
      * Destructor.

--- a/src/PopupLogo.h
+++ b/src/PopupLogo.h
@@ -100,8 +100,8 @@ class LogoPopup: public QLabel
 
 public:
 
-    LogoPopup( const QString & logoName,
-               QWidget *       parent = 0 );
+    explicit LogoPopup( const QString & logoName,
+                        QWidget *       parent = 0 );
 
     virtual ~LogoPopup();
 

--- a/src/ProgressDialog.h
+++ b/src/ProgressDialog.h
@@ -49,7 +49,7 @@ public:
      * If 'parent' is 0, it will use MainWindow::instance(), so the dialog is
      * centered above the main window.
      **/
-    ProgressDialog( const QString & text, QWidget * parent = 0 );
+    explicit ProgressDialog( const QString & text, QWidget * parent = 0 );
 
     /**
      * Destructor.

--- a/src/SearchFilter.h
+++ b/src/SearchFilter.h
@@ -49,9 +49,9 @@ public:
      * - If it starts with "=", it uses "ExactMatch".
      * - If it's empty, it uses "SelectAll".
      **/
-    SearchFilter( const QString & pattern,
-                  FilterMode      filterMode        = Auto,
-                  FilterMode      defaultFilterMode = StartsWith );
+    explicit SearchFilter( const QString & pattern,
+                           FilterMode      filterMode        = Auto,
+                           FilterMode      defaultFilterMode = StartsWith );
 
     /**
      * Check if a string matches this filter.

--- a/src/Workflow.h
+++ b/src/Workflow.h
@@ -59,7 +59,7 @@ public:
      * needed. For each step, WorkflowStep::setWorkflow() is called to set its
      * parent workflow to this one.
      **/
-    Workflow( const WorkflowStepList & steps );
+    explicit Workflow( const WorkflowStepList & steps );
 
     /**
      * Destructor. This will delete all added workflow steps.

--- a/src/ZyppLogger.h
+++ b/src/ZyppLogger.h
@@ -35,7 +35,7 @@ class ZyppLogger;
  **/
 struct ZyppLogLineWriter: public zypp::base::LogControl::LineWriter
 {
-    ZyppLogLineWriter( ZyppLogger * zyppLogger )
+    explicit ZyppLogLineWriter( ZyppLogger * zyppLogger )
         : _zyppLogger( zyppLogger )
         {}
 


### PR DESCRIPTION
Following the Cpp Core Guidelines.
Found by Cppcheck (noExplicitConstructor).

Only Fsize is left out due to some Boost Multiprecision mismatch when addding `explicit`.