### PR TITLE
Fix: pass functor directly instead of using boost::ref

### DIFF
--- a/src/YQPkgHistoryDialog.cc
+++ b/src/YQPkgHistoryDialog.cc
@@ -161,7 +161,7 @@ YQPkgHistoryDialog::populate()
     YQPkgHistoryItemCollector itemCollector( _datesTree, _actionsTree );
     zypp::parser::HistoryLogReader reader( FILENAME,
                                            zypp::parser::HistoryLogReader::Options(),
-                                           boost::ref( itemCollector ) );
+                                           itemCollector );
     try
     {
 	reader.readAll();


### PR DESCRIPTION
This fixes compilation with recent boost 1.88.0 on Open Madriva. 
It supplements commits https://github.com/shundhammer/myrlyn/commit/49c0a74c1cf0efb9e1eb9e0ae33058ec7e63d968 needed for #92