### PR TITLE
Refresh pattern list after successful package commits

### DIFF
--- a/src/PkgCommitPage.cc
+++ b/src/PkgCommitPage.cc
@@ -29,6 +29,7 @@
 #include "PkgTaskListWidget.h"
 #include "ProgressDialog.h"
 #include "MyrlynApp.h"
+#include "YQPkgSelector.h"
 #include "YQZypp.h"
 #include "YQi18n.h"
 #include "utf8.h"
@@ -215,6 +216,12 @@ void PkgCommitPage::realCommit()
         zypp::getZYpp()->commit( commitPolicy() );
 
         logInfo() << "Package transactions done" << endl;
+
+        if ( ! MyrlynApp::isOptionSet( OptDryRun ) &&
+             ! MyrlynApp::isOptionSet( OptDownloadOnly ) )
+        {
+            MyrlynApp::instance()->pkgSel()->markPoolReloadedAfterCommit();
+        }
     }
     catch ( const zypp::target::TargetAbortedException & ex )
     {

--- a/src/YQPkgPatternList.cc
+++ b/src/YQPkgPatternList.cc
@@ -169,6 +169,40 @@ YQPkgPatternList::fillList()
 }
 
 
+void
+YQPkgPatternList::refillListPreservingSelection()
+{
+    string selectedPatternName;
+
+    if ( selection() && selection()->selectable() )
+        selectedPatternName = selection()->selectable()->name();
+
+    fillList();
+
+    if ( ! selectedPatternName.empty() )
+    {
+        QTreeWidgetItemIterator it( this );
+
+        while ( *it )
+        {
+            YQPkgPatternListItem * patternItem = dynamic_cast<YQPkgPatternListItem *>( *it );
+
+            if ( patternItem &&
+                 patternItem->selectable() &&
+                 patternItem->selectable()->name() == selectedPatternName )
+            {
+                setCurrentItem( patternItem );
+                return;
+            }
+
+            ++it;
+        }
+    }
+
+    selectSomething();
+}
+
+
 YQPkgPatternCategoryItem *
 YQPkgPatternList::category( const QString & categoryName )
 {

--- a/src/YQPkgPatternList.h
+++ b/src/YQPkgPatternList.h
@@ -106,6 +106,12 @@ public slots:
     void fillList();
 
     /**
+     * Refill the pattern list from the current libzypp pool and restore the
+     * previously selected pattern by name if it still exists.
+     **/
+    void refillListPreservingSelection();
+
+    /**
      * Dispatcher slot for mouse click: cycle status depending on column.
      * For pattern category items, emulate tree open / close behaviour.
      *

--- a/src/YQPkgSelector.cc
+++ b/src/YQPkgSelector.cc
@@ -135,6 +135,7 @@ YQPkgSelector::YQPkgSelector( QWidget * parent )
     , _excludeDevelPkgs(0)
     , _excludeDebugInfoPkgs(0)
     , _useRpmGroups( USE_RPM_GROUPS )
+    , _poolReloadedAfterCommit( false )
 {
     _instance = this;
 
@@ -1206,6 +1207,14 @@ YQPkgSelector::connectPatternList()
 
 
 void
+YQPkgSelector::markPoolReloadedAfterCommit()
+{
+    logInfo() << "Marking package selector views stale after commit" << endl;
+    _poolReloadedAfterCommit = true;
+}
+
+
+void
 YQPkgSelector::reset()
 {
     logDebug() << "Reset" << endl;
@@ -1219,6 +1228,13 @@ YQPkgSelector::reset()
 
     if ( _pkgList )
         _pkgList->clear();
+
+    if ( _poolReloadedAfterCommit && _patternList )
+    {
+        logInfo() << "Rebuilding pattern list after commit" << endl;
+        _patternList->refillListPreservingSelection();
+        _poolReloadedAfterCommit = false;
+    }
 
     if ( _filters )
         _filters->reloadCurrentPage();

--- a/src/YQPkgSelector.h
+++ b/src/YQPkgSelector.h
@@ -99,6 +99,12 @@ public:
 public slots:
 
     /**
+     * Mark persistent selector views as stale after a successful package
+     * commit because libzypp may reload the pool and replace selectables.
+     **/
+    void markPoolReloadedAfterCommit();
+
+    /**
      * Reset the data in connected views and reset the resolver.
      **/
     void reset();
@@ -479,6 +485,7 @@ protected:
     YQPkgObjList::ExcludeRule *         _excludeDebugInfoPkgs;
 
     bool                                _useRpmGroups;
+    bool                                _poolReloadedAfterCommit;
 
     static YQPkgSelector *              _instance;
 };


### PR DESCRIPTION

Closes #130

## Summary

This fixes installed patterns appearing unchecked after a successful package
commit.

After a commit, libzypp may reload its pool. The existing pattern list can then
still point to old objects from before that reload. When a later package action
updates the icons, installed patterns can appear unchecked even though libzypp
still reports them as installed.

This patch marks the selector views as stale after a successful real commit. On
the next selector reset, it rebuilds the pattern list from the current pool
before reloading the current page. It also keeps the previously selected pattern
selected when possible.

The relevant path is:

- `PkgCommitPage::realCommit()` marks the selector stale after a successful
  commit.
- `YQPkgSelector::reset()` rebuilds the pattern list before reloading the
  current page.
- `YQPkgPatternList::refillListPreservingSelection()` refills the list and
  restores the selected pattern by name when possible.

## Testing

Tested locally with `kmousetool`:

1. Started with `kmousetool` not installed.
2. Installed `kmousetool` in Myrlyn and committed the transaction.
3. Returned to package selection.
4. Marked `kmousetool` for deletion.
5. Installed patterns in the left pattern list remained visually installed.

An instrumented build also confirmed that the pattern list used current
libzypp objects again after the rebuild.
