### PR TITLE
Highlight package version changes in the package list

### DIFF
--- a/src/YQPkgObjList.cc
+++ b/src/YQPkgObjList.cc
@@ -17,6 +17,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QDebug>
+#include <QFont>
 #include <QHeaderView>
 #include <QKeyEvent>
 #include <QMenu>
@@ -904,6 +905,25 @@ YQPkgObjListItem::init()
     if ( installed && ! candidate )
         _installedIsNewer = true;
 
+    const bool candidateVersionChanged =
+        candidate && installed && _candidateIsNewer &&
+        ( candidate->edition().epoch()   != installed->edition().epoch() ||
+          candidate->edition().version() != installed->edition().version() );
+
+    if ( versionCol() >= 0 )
+    {
+        QFont versionFont = font( versionCol() );
+        versionFont.setBold( candidateVersionChanged );
+        setFont( versionCol(), versionFont );
+    }
+
+    if ( instVersionCol() >= 0 && instVersionCol() != versionCol() )
+    {
+        QFont instVersionFont = font( instVersionCol() );
+        instVersionFont.setBold( candidateVersionChanged );
+        setFont( instVersionCol(), instVersionFont );
+    }
+
     if ( nameCol()    >= 0 )  setText( nameCol(),     zyppObj()->name()    );
     if ( summaryCol() >= 0 )  setText( summaryCol(),  zyppObj()->summary() );
 
@@ -1509,5 +1529,4 @@ void YQPkgObjList::slotCustomContextMenu( const QPoint& pos )
             contextMenu->popup( viewport()->mapToGlobal( pos ) );
     }
 }
-
 


### PR DESCRIPTION

Closes #132

## Summary

This makes real package version changes easier to spot in the package list.

Myrlyn already uses blue text in the version column when the available package
edition is newer than the installed edition. This patch keeps that behavior and
adds bold text when the package epoch or version changed.

Examples:

- `0.16.20` to `0.16.22`: blue and bold
- `6.6.4-1.2` to `6.6.4-2.1`: blue, but not bold

The check uses `zypp::Edition::epoch()` and `zypp::Edition::version()`, so RPM
release-only changes are not treated as real version changes.

## Testing

Built locally and tested in the `Updates` tab.

Packages with real version changes were shown in bold. Release-only updates
kept the existing blue text but stayed normal weight.
